### PR TITLE
Remove test stuff from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "Robowhois": "src/",
-            "Stub" : "test/",
-            "test" : ""
+            "Robowhois": "src/"
         }
     },
     "require": {


### PR DESCRIPTION
The right way to do this is to have your own bootstrap file that includes composer's autoload and then add the namespaces you need for your tests, see: https://github.com/composer/composer/blob/master/tests/bootstrap.php
